### PR TITLE
Implement client profile view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Referral from './pages/Referral';
 import Products from './pages/Products';
 import Schedule from './pages/Schedule';
 import ClientManagement from './pages/ClientManagement';
+import ClientProfile from './pages/ClientProfile';
 
 const queryClient = new QueryClient();
 
@@ -34,6 +35,7 @@ export default function App() {
               <Route path="/admin/blogs/new" element={<BlogEditor />} />
               <Route path="/admin/blogs/edit/:id" element={<BlogEditor />} />
               <Route path="/admin/clients" element={<ClientManagement />} />
+              <Route path="/admin/clients/:id" element={<ClientProfile />} />
               <Route path="/program-features" element={<ProgramFeatures />} />
               <Route path="/getting-started" element={<GettingStarted />} />
               <Route path="/workout-section" element={<WorkoutSection />} />

--- a/src/components/WeightGraph.tsx
+++ b/src/components/WeightGraph.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+interface WeightGraphProps {
+  weights: { [day: string]: number };
+}
+
+export default function WeightGraph({ weights }: WeightGraphProps) {
+  const entries = Object.entries(weights)
+    .map(([day, weight]) => ({ day: parseInt(day, 10), weight }))
+    .sort((a, b) => a.day - b.day);
+
+  if (entries.length === 0) {
+    return <p className="text-gray-600">No weight data available.</p>;
+  }
+
+  const width = 500;
+  const height = 300;
+  const padding = 40;
+
+  const minX = entries[0].day;
+  const maxX = entries[entries.length - 1].day;
+  const minY = Math.min(...entries.map(e => e.weight));
+  const maxY = Math.max(...entries.map(e => e.weight));
+
+  const xScale = (x: number) =>
+    padding + ((x - minX) * (width - padding * 2)) / Math.max(1, maxX - minX);
+  const yScale = (y: number) =>
+    height - padding - ((y - minY) * (height - padding * 2)) / Math.max(1, maxY - minY);
+
+  const points = entries.map(e => `${xScale(e.day)},${yScale(e.weight)}`).join(' ');
+
+  return (
+    <svg width={width} height={height} className="mx-auto mt-4">
+      <polyline
+        points={points}
+        fill="none"
+        stroke="#14b8a6"
+        strokeWidth="2"
+      />
+      {entries.map(e => (
+        <circle
+          key={e.day}
+          cx={xScale(e.day)}
+          cy={yScale(e.weight)}
+          r={3}
+          fill="#14b8a6"
+        />
+      ))}
+      {/* Axes */}
+      <line
+        x1={padding}
+        y1={padding}
+        x2={padding}
+        y2={height - padding}
+        stroke="#e5e7eb"
+      />
+      <line
+        x1={padding}
+        y1={height - padding}
+        x2={width - padding}
+        y2={height - padding}
+        stroke="#e5e7eb"
+      />
+    </svg>
+  );
+}

--- a/src/pages/ClientManagement.tsx
+++ b/src/pages/ClientManagement.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import { collection, getDocs, addDoc, updateDoc, doc, deleteDoc, serverTimestamp } from 'firebase/firestore';
 import { db, auth } from '../lib/firebase';
 import { useRequireAuth } from '../lib/auth';
@@ -437,7 +438,12 @@ export default function ClientManagement() {
                 {clients?.map((client) => (
                   <tr key={client.id} className="hover:bg-gray-50">
                     <td className="px-4 py-4 whitespace-nowrap text-sm font-medium text-gray-900 sticky left-0 bg-white z-10">
-                      {client.name}
+                      <Link
+                        to={`/admin/clients/${client.id}`}
+                        className="text-teal-600 hover:text-teal-800"
+                      >
+                        {client.name}
+                      </Link>
                     </td>
                     <td className="px-4 py-4 text-sm text-gray-600 max-w-[150px] truncate">
                       {client.notes}

--- a/src/pages/ClientProfile.tsx
+++ b/src/pages/ClientProfile.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../lib/firebase';
+import WeightGraph from '../components/WeightGraph';
+import { useRequireAuth } from '../lib/auth';
+
+interface Client {
+  id: string;
+  name: string;
+  startDate: string;
+  startWeight: number;
+  notes: string;
+  weights: { [key: string]: number };
+}
+
+export default function ClientProfile() {
+  useRequireAuth();
+  const { id } = useParams();
+
+  const { data: client, isLoading } = useQuery({
+    queryKey: ['client', id],
+    queryFn: async () => {
+      if (!id) return null;
+      const docRef = doc(db, 'clients', id);
+      const snapshot = await getDoc(docRef);
+      if (!snapshot.exists()) return null;
+      return { id: snapshot.id, ...snapshot.data() } as Client;
+    },
+  });
+
+  if (isLoading) return <div className="pt-24">Loading...</div>;
+  if (!client) return <div className="pt-24">Client not found</div>;
+
+  return (
+    <div className="pt-24 pb-16">
+      <div className="max-w-3xl mx-auto px-4">
+        <Link to="/admin/clients" className="text-teal-600 hover:text-teal-800">
+          ← Back to Clients
+        </Link>
+        <h1 className="text-3xl font-bold mt-4 mb-2">{client.name}</h1>
+        <p className="text-gray-600 mb-4">Start Date: {client.startDate}</p>
+        <p className="text-gray-600 mb-4">Start Weight: {client.startWeight} kg</p>
+        {client.notes && (
+          <p className="text-gray-700 mb-4">Notes: {client.notes}</p>
+        )}
+
+        <div className="bg-white rounded-xl shadow p-6">
+          <h2 className="text-xl font-semibold mb-2">Weight Progress</h2>
+          <WeightGraph weights={client.weights || {}} />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- link client names to a profile page in ClientManagement
- show detailed client info and weight graph on new page
- add simple SVG-based WeightGraph component
- register ClientProfile route

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: JSX IntrinsicElements errors in WorkoutSection.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6845bffea7ac832583245b3a939c292c