### PR TITLE
Remove purple theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 FitWithRishabh
 ===============
 
-This project is a fitness coaching platform built with React, TypeScript and Vite. It uses the **shadcn/ui** component library for a modern dark UI with purple accents.
+This project is a fitness coaching platform built with React, TypeScript and Vite. It uses the **shadcn/ui** component library for a modern dark UI with blue accents.
 
 ### Notes
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -10,7 +10,7 @@ export default function Hero() {
       {/* Background Elements */}
       <div className="absolute inset-0">
         <div className="absolute top-20 left-10 w-72 h-72 bg-primary/20 rounded-full blur-3xl animate-float" />
-        <div className="absolute bottom-20 right-10 w-96 h-96 bg-purple-500/20 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }} />
+        <div className="absolute bottom-20 right-10 w-96 h-96 bg-primary/20 rounded-full blur-3xl animate-float" style={{ animationDelay: '2s' }} />
         <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-[600px] h-[600px] bg-primary/10 rounded-full blur-3xl" />
       </div>
 

--- a/src/index.css
+++ b/src/index.css
@@ -10,7 +10,7 @@
     --card-foreground: 240 10% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 240 10% 3.9%;
-    --primary: 262 83% 58%;
+    --primary: 217 91% 60%;
     --primary-foreground: 210 40% 98%;
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;
@@ -22,7 +22,7 @@
     --destructive-foreground: 210 40% 98%;
     --border: 240 5.9% 90%;
     --input: 240 5.9% 90%;
-    --ring: 262 83% 58%;
+    --ring: 217 91% 60%;
     --radius: 0.75rem;
   }
 
@@ -33,7 +33,7 @@
     --card-foreground: 0 0% 98%;
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 262 83% 58%;
+    --primary: 217 91% 60%;
     --primary-foreground: 240 5.9% 10%;
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
@@ -45,7 +45,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
-    --ring: 262 83% 58%;
+    --ring: 217 91% 60%;
   }
 }
 
@@ -64,13 +64,13 @@
   background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
 }
 
-.gradient-purple {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+.gradient-blue {
+  background: linear-gradient(135deg, #3b82f6 0%, #1e40af 100%);
 }
 
 .gradient-card {
-  background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-  border: 1px solid rgba(102, 126, 234, 0.2);
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, rgba(30, 64, 175, 0.1) 100%);
+  border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
 /* Glassmorphism effect */
@@ -124,16 +124,16 @@
 
 @keyframes glow {
   from {
-    box-shadow: 0 0 20px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 0 20px rgba(59, 130, 246, 0.3);
   }
   to {
-    box-shadow: 0 0 30px rgba(102, 126, 234, 0.6);
+    box-shadow: 0 0 30px rgba(59, 130, 246, 0.6);
   }
 }
 
 /* Text gradient */
 .text-gradient {
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: linear-gradient(135deg, #3b82f6 0%, #1e40af 100%);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;

--- a/src/pages/ClientProfile.tsx
+++ b/src/pages/ClientProfile.tsx
@@ -315,8 +315,8 @@ export default function ClientProfile() {
                   <p className="text-sm text-gray-600">Target: {client.goalWeight} kg</p>
                 )}
               </div>
-              <div className="p-3 bg-purple-100 rounded-full">
-                <Target className="w-6 h-6 text-purple-600" />
+              <div className="p-3 bg-primary/10 rounded-full">
+                <Target className="w-6 h-6 text-primary" />
               </div>
             </div>
           </motion.div>
@@ -441,12 +441,12 @@ export default function ClientProfile() {
                   </span>
                 </div>
 
-                <div className="flex items-center justify-between p-3 bg-purple-50 rounded-lg">
+                <div className="flex items-center justify-between p-3 bg-primary/5 rounded-lg">
                   <div className="flex items-center gap-3">
-                    <Zap className="w-5 h-5 text-purple-600" />
+                    <Zap className="w-5 h-5 text-primary" />
                     <span className="font-medium">Motivation</span>
                   </div>
-                  <span className="text-purple-600 font-semibold">
+                  <span className="text-primary font-semibold">
                     {client.status === 'active' ? 'High' : 'Moderate'}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
- switch the primary color variables to blue
- update gradients and glow effects
- update hero background circle to use primary color
- adjust client profile stats widgets to use primary instead of purple
- note blue accents in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6852a0b7b4f083259d454488c2569742