### PR TITLE
Fix lucide icon typing in ProcessStep

### DIFF
--- a/src/components/program/ProcessStep.tsx
+++ b/src/components/program/ProcessStep.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { LucideIcon } from 'lucide-react';
 import * as Icons from 'lucide-react';
 
 interface ProcessStepProps {
@@ -10,7 +11,7 @@ interface ProcessStepProps {
 }
 
 export default function ProcessStep({ step, title, description, icon, isActive }: ProcessStepProps) {
-  const Icon = Icons[icon as keyof typeof Icons] || Icons.Circle;
+  const Icon: LucideIcon = Icons[icon as keyof typeof Icons] || Icons.Circle;
 
   return (
     <div className={`flex-1 relative ${isActive ? 'scale-105' : 'opacity-70'}`}>


### PR DESCRIPTION
## Summary
- import `LucideIcon` type and use it for ProcessStep icons

## Testing
- `npm run lint` *(fails: Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_6855c5d67c388325b4bc2c83e4709e72